### PR TITLE
Add reference to CSP

### DIFF
--- a/specification/7___literature.adoc
+++ b/specification/7___literature.adoc
@@ -1,6 +1,8 @@
 [bibliography]
 == References
 
+- [[[CSP]]] SET Level: **Credible Simulation Process**. August 2021. https://setlevel.de/assets/forschungsergebnisse/Credible-Simulation-Process.pdf
+
 - [[[RFC2119]]] Bradner, S.: **Key words for use in RFCs to Indicate Requirement Levels**. RFC 2119, March 1997. https://www.ietf.org/rfc/rfc2119.txt
 
 - [[[SEMVER200]]] Preston-Werner, T.: **Semantic Versioning 2.0.0**. https://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
As the first version of CSP is released, it would be good to link to it.
Probably also needs a reference in the introduction.

I'm not sure if the used link is intended to be a permanent link to the newest version.
Therfore, I referred to [CSP] instead [CSP11]