### PR TITLE
Address minor obvious typos

### DIFF
--- a/specification/1___introduction.adoc
+++ b/specification/1___introduction.adoc
@@ -33,7 +33,7 @@ The essential core of the SSP Traceability Specification document is the documen
 The detail description of the SSP Traceability data formats is subject of <<sec-stc>> through <<sec-srmd>>.
 <<sec-stc>> describes a common set of re-usable metadata description elements.
 <<sec-dtmd>> describes how the SSP Traceability data format for documenting Credible Decision Processes are structured and <<sec-stmd>> describes the structure of SSP Traceability data formats for the documentation of Credible Simulation Processes.
-<<sec-srmd>> additionally describes a data format for documenting resource metadata based on resources in the sense of SSP Traceability.
+<<sec-srmd>> additionally describes a data format for documenting metadata of individual resources in the sense of SSP Traceability.
 <<sec-ssptraceabilitypackaging>> describes how SSP Traceability files can be bundled into an SSP Traceability package.
 The SSP traceability specification concludes with a list of other applicable documents such as relevant standards and referenced literature.
 

--- a/specification/1___introduction.adoc
+++ b/specification/1___introduction.adoc
@@ -33,7 +33,7 @@ The essential core of the SSP Traceability Specification document is the documen
 The detail description of the SSP Traceability data formats is subject of <<sec-stc>> through <<sec-srmd>>.
 <<sec-stc>> describes a common set of re-usable metadata description elements.
 <<sec-dtmd>> describes how the SSP Traceability data format for documenting Credible Decision Processes are structured and <<sec-stmd>> describes the structure of SSP Traceability data formats for the documentation of Credible Simulation Processes.
-<<sec-srmd>> additionally describes a data format for documenting resource metadata von resources in the sense of SSP Traceability.
+<<sec-srmd>> additionally describes a data format for documenting resource metadata based on resources in the sense of SSP Traceability.
 <<sec-ssptraceabilitypackaging>> describes how SSP Traceability files can be bundled into an SSP Traceability package.
 The SSP traceability specification concludes with a list of other applicable documents such as relevant standards and referenced literature.
 

--- a/specification/3___overview.adoc
+++ b/specification/3___overview.adoc
@@ -8,9 +8,9 @@ As improving traceability of design decisions and simulations is one the core ob
 
 To enable the documentation of process-relevant information and resources for a Credible Decision Process or a Credible Simulation Process the SSP Traceability Specification introduces the GlueParticle Approach:
 
-* The **GluePartice Approach** is a concept for bundling and file-based transfer of process-relevant information and resources of a Credible Decision Process or a Credible Simulation Process.
+* The **GlueParticle Approach** is a concept for bundling and file-based transfer of process-relevant information and resources of a Credible Decision Process or a Credible Simulation Process.
 
-* A **GluePartice** is a bundle of process-relevant information and resources for a Credible Decision Process or a Credible Simulation Process.
+* A **GlueParticle** is a bundle of process-relevant information and resources for a Credible Decision Process or a Credible Simulation Process.
 The form in which this bundle exists, e.g. whether it is stored as a file or in a database or a specific data format, is not specified.
 
 * A **GlueParticle file** is a GlueParticle that is in a file-based representation and can therefore be transferred between tools or organizational units such as people, departments, or companies.


### PR DESCRIPTION
Fixed obvious typo: German "von" replaced by "based on"